### PR TITLE
juce::InputStream+OutputStream based persistency methods

### DIFF
--- a/modules/juce_audio_plugin_client/ARA/juce_ARADocumentController.cpp
+++ b/modules/juce_audio_plugin_client/ARA/juce_ARADocumentController.cpp
@@ -181,6 +181,30 @@ void ARADocumentController::doNotifyModelUpdates() noexcept
 
 //==============================================================================
 
+bool ARADocumentController::restoreObjectsFromStream (InputStream& input, ARA::PlugIn::RestoreObjectsFilter* filter) noexcept
+{
+    return true;
+}
+
+bool ARADocumentController::storeObjectsToStream (OutputStream& output, ARA::PlugIn::StoreObjectsFilter* filter) noexcept
+{
+    return true;
+}
+
+bool ARADocumentController::doRestoreObjectsFromArchive (ARA::PlugIn::HostArchiveReader* archiveReader, ARA::PlugIn::RestoreObjectsFilter* filter) noexcept
+{
+    ARAHostArchiveInputStream input (archiveReader);
+    return restoreObjectsFromStream (input, filter);
+}
+
+bool ARADocumentController::doStoreObjectsToArchive (ARA::PlugIn::HostArchiveWriter* archiveWriter, ARA::PlugIn::StoreObjectsFilter* filter) noexcept
+{
+    ARAHostArchiveOutputStream output (archiveWriter);
+    return storeObjectsToStream (output, filter);
+}
+
+//==============================================================================
+
 ARA::PlugIn::MusicalContext* ARADocumentController::doCreateMusicalContext (ARA::PlugIn::Document* document, ARA::ARAMusicalContextHostRef hostRef) noexcept
 {
     return new ARAMusicalContext (static_cast<ARADocument*>(document), hostRef);

--- a/modules/juce_audio_plugin_client/ARA/juce_ARADocumentController.h
+++ b/modules/juce_audio_plugin_client/ARA/juce_ARADocumentController.h
@@ -83,7 +83,8 @@ public:
     //==============================================================================
     // Override document controller methods here
     // If you are subclassing ARADocumentController, make sure to call the base class
-    // implementations of any overridden function, except for any doCreate...().
+    // implementations of any overridden function, except for any doCreate...()
+    // or where specified.
 
 private:
     // some helper macros to ease repeated declaration & implementation of notification functions below:
@@ -125,6 +126,14 @@ protected:
     void willBeginEditing() noexcept override;
     void didEndEditing() noexcept override;
     void doNotifyModelUpdates() noexcept override;
+
+    // Persistency Management
+    // * Overriding these methods does not require calling the base class.
+    // * You may override either the methods with JUCE streams or with the ARA SDK's archive reader/writer.
+    virtual bool restoreObjectsFromStream (InputStream& input, ARA::PlugIn::RestoreObjectsFilter* filter) noexcept;
+    virtual bool storeObjectsToStream (OutputStream& output, ARA::PlugIn::StoreObjectsFilter* filter) noexcept;
+    bool doRestoreObjectsFromArchive (ARA::PlugIn::HostArchiveReader* archiveReader, ARA::PlugIn::RestoreObjectsFilter* filter) noexcept override;
+    bool doStoreObjectsToArchive (ARA::PlugIn::HostArchiveWriter* archiveWriter, ARA::PlugIn::StoreObjectsFilter* filter) noexcept override;
 
     // Document callbacks
     ARA::PlugIn::Document* doCreateDocument (ARA::PlugIn::DocumentController* documentController) noexcept override;

--- a/modules/juce_audio_plugin_client/ARA/juce_ARAStreams.cpp
+++ b/modules/juce_audio_plugin_client/ARA/juce_ARAStreams.cpp
@@ -1,0 +1,62 @@
+#include "juce_ARAStreams.h"
+
+namespace juce
+{
+
+ARAHostArchiveInputStream::ARAHostArchiveInputStream (ARA::PlugIn::HostArchiveReader* reader)
+: archiveReader (reader), position (0), size (reader->getArchiveSize())
+{
+}
+
+int ARAHostArchiveInputStream::read (void* destBuffer, int maxBytesToRead)
+{
+    const int bytesToRead = std::min (maxBytesToRead, (int) (size - position));
+    const int result =
+        archiveReader->readBytesFromArchive (
+            position,
+            bytesToRead,
+            (ARA::ARAByte*) destBuffer)
+        ? bytesToRead
+        : 0;
+    position += result;
+    return result;
+}
+
+bool ARAHostArchiveInputStream::setPosition (int64 newPosition)
+{
+    if (newPosition >= (int64) size)
+        return false;
+    position = (size_t) newPosition;
+    return true;
+}
+
+bool ARAHostArchiveInputStream::isExhausted()
+{
+    return position >= size;
+}
+
+ARAHostArchiveOutputStream::ARAHostArchiveOutputStream (ARA::PlugIn::HostArchiveWriter* writer)
+: archiveWriter (writer), position (0)
+{
+}
+
+bool ARAHostArchiveOutputStream::write (const void* dataToWrite, size_t numberOfBytes)
+{
+    if (! archiveWriter->writeBytesToArchive (
+            position,
+            numberOfBytes,
+            (const ARA::ARAByte*) dataToWrite))
+        return false;
+    position += numberOfBytes;
+    return true;
+}
+
+bool ARAHostArchiveOutputStream::setPosition (int64 newPosition)
+{
+    if (newPosition > (int64) std::numeric_limits<size_t>::max())
+        return false;
+    position = (size_t) newPosition;
+    return true;
+}
+
+} // namespace juce

--- a/modules/juce_audio_plugin_client/ARA/juce_ARAStreams.h
+++ b/modules/juce_audio_plugin_client/ARA/juce_ARAStreams.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "juce_ARA_audio_plugin.h"
+
+namespace juce
+{
+
+class ARAHostArchiveInputStream : public InputStream
+{
+public:
+    ARAHostArchiveInputStream (ARA::PlugIn::HostArchiveReader*);
+
+    int64 getPosition() override { return (int64) position; }
+    int64 getTotalLength() override { return (int64) size; }
+
+    bool setPosition (int64) override;
+    bool isExhausted() override;
+    int read (void*, int) override;
+
+private:
+    ARA::PlugIn::HostArchiveReader* archiveReader;
+    size_t position, size;
+};
+
+class ARAHostArchiveOutputStream : public OutputStream
+{
+public:
+    ARAHostArchiveOutputStream (ARA::PlugIn::HostArchiveWriter*);
+
+    int64 getPosition() override { return (int64) position; }
+    void flush() override {}
+
+    bool setPosition (int64) override;
+    bool write (const void*, size_t) override;
+
+private:
+    ARA::PlugIn::HostArchiveWriter* archiveWriter;
+    size_t position;
+};
+
+} // namespace juce

--- a/modules/juce_audio_plugin_client/ARA/juce_ARA_audio_plugin.cpp
+++ b/modules/juce_audio_plugin_client/ARA/juce_ARA_audio_plugin.cpp
@@ -12,6 +12,7 @@
 #include "juce_ARADocumentController.cpp"
 #include "juce_ARAAudioReaders.cpp"
 #include "juce_ARAPlugInInstanceRoles.cpp"
+#include "juce_ARAStreams.cpp"
 #include "juce_AudioProcessor_ARAExtensions.cpp"
 
 namespace juce

--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client.h
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client.h
@@ -121,4 +121,5 @@
  #include "ARA/juce_AudioProcessor_ARAExtensions.h"
  #include "ARA/juce_ARAAudioReaders.h"
  #include "ARA/juce_ARAPlugInInstanceRoles.h"
+ #include "ARA/juce_ARAStreams.h"
 #endif


### PR DESCRIPTION
JUCE has the `InputStream` and `OutputStream` classes, and various classes based on them such as `GZIPCompressorOutputStream` etc. This change adds adapters to these from `HostArchiveReader` and `HostArchiveWriter`, and adds the document controller methods `restoreObjectsFromStream` and `storeObjectsToStream`, which the user may use instead of the "bare-bones" `doRestoreObjectsFromArchive`/`doStoreObjectsToArchive`.